### PR TITLE
Add version command to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ iOSInjectionProject/
 
 # macOS
 **/*.DS_Store
+
+# Built binary
+geotagger

--- a/Sources/CLI/Geotagger.swift
+++ b/Sources/CLI/Geotagger.swift
@@ -20,7 +20,8 @@ enum CLIError: Error {
 struct GeoTaggerCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "geotagger",
-        abstract: "A tool for geotagging photos using GPX tracks and other geotagged photos as location references."
+        abstract: "A tool for geotagging photos using GPX tracks and other geotagged photos as location references.",
+        version: Version.full
     )
     
     @Option(name: .shortAndLong, help: "Path to directory or file containing GPX or image files that will be used as location anchors")

--- a/Sources/CLI/Version.swift
+++ b/Sources/CLI/Version.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum Version {
+    static let number = "VERSION_NUMBER"
+    static let commitHash = "GIT_COMMIT_HASH"
+    
+    static var full: String {
+        return "v\(number) (\(commitHash))"
+    }
+}

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,41 @@
 #!/bin/sh
 
+# Fetch tags from remote
+echo "Fetching tags from remote..."
+git fetch --tags
+
+# Get current version from git tag
+CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+CURRENT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Get latest tag from main branch
+LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+
+# Check if current commit has the latest tag
+if [ -n "$LATEST_TAG" ] && [ "v$CURRENT_VERSION" != "$LATEST_TAG" ]; then
+    echo "Warning: Current version (v$CURRENT_VERSION) is not the latest tag from main branch ($LATEST_TAG)"
+    echo "Do you want to continue? (y/n)"
+    read -r response
+    if [ "$response" != "y" ] && [ "$response" != "Y" ]; then
+        echo "Build cancelled."
+        exit 1
+    fi
+fi
+
+# Set version and commit hash for build
+VERSION=$CURRENT_VERSION
+COMMIT_HASH=$CURRENT_COMMIT
+
+# Create temporary Version.swift with actual values
+VERSION_FILE="Sources/CLI/Version.swift"
+cp "$VERSION_FILE" "$VERSION_FILE.backup"
+
+sed -i '' \
+    -e "s/VERSION_NUMBER/$VERSION/g" \
+    -e "s/GIT_COMMIT_HASH/$COMMIT_HASH/g" \
+    "$VERSION_FILE"
+
 # Build for arm64
 swift build \
     --configuration release \
@@ -15,5 +51,9 @@ lipo -create -output geotagger \
     .build/arm64-apple-macosx/release/geotagger \
     .build/x86_64-apple-macosx/release/geotagger
 
+# Restore original Version.swift
+mv "$VERSION_FILE.backup" "$VERSION_FILE"
+
 echo "Universal binary created successfully!"
+echo "Version: v$VERSION ($COMMIT_HASH)"
 file geotagger


### PR DESCRIPTION
## Summary
- Implemented `--version` flag that displays version in format: `v2025.1 (commit_hash)`
- Version automatically synchronizes with git tags
- Added version validation to release script with user prompt for outdated versions

## Implementation details
- Created `Version.swift` with replaceable constants for version number and git commit hash
- Updated `release.sh` to inject actual values during build process
- Added automatic tag fetching and version comparison against main branch
- Updated `.gitignore` to exclude the built binary

## Test plan
- [x] Build with `./release.sh` and verify version injection works
- [x] Run `./geotagger --version` and verify output format
- [x] Test version warning when building from older tag
- [x] Verify prompt allows cancelling or continuing build