### PR TITLE
Add time offset support to PHAssetGeotaggingItem

### DIFF
--- a/Sources/CLI/LoggingGeotaggingItem.swift
+++ b/Sources/CLI/LoggingGeotaggingItem.swift
@@ -42,9 +42,9 @@ struct LoggingGeotaggingItem: GeotaggingItemProtocol {
         }
     }
     
-    func skip(with error: Error) throws {
+    func skip(with error: Error) async throws {
         do {
-            try self.item.skip(with: error)
+            try await self.item.skip(with: error)
             self.logSkip(with: error)
         } catch {
             self.logError("Failed to skip item", error: error)

--- a/Sources/Geotagger/Geotagger.swift
+++ b/Sources/Geotagger/Geotagger.swift
@@ -36,7 +36,7 @@ public final class Geotagger {
                     case .success(let geotag):
                         try? await item.apply(geotag)
                     case .failure(let error):
-                        try? item.skip(with: error)
+                        try? await item.skip(with: error)
                     }
                 }
             }

--- a/Sources/Geotagger/GeotaggingItemProtocol.swift
+++ b/Sources/Geotagger/GeotaggingItemProtocol.swift
@@ -11,6 +11,6 @@ public protocol GeotaggingItemProtocol: Sendable {
     var id: String { get }
     var date: Date? { get }
     
-    func skip(with error: Error) throws
+    func skip(with error: Error) async throws
     func apply(_ geotag: Geotag) async throws
 }

--- a/Sources/Geotagger/ImageIO/ImageIOGeotaggingItem.swift
+++ b/Sources/Geotagger/ImageIO/ImageIOGeotaggingItem.swift
@@ -43,7 +43,7 @@ public struct ImageIOGeotaggingItem: GeotaggingItemProtocol {
         }
     }
     
-    public func skip(with error: Error) throws {
+    public func skip(with error: Error) async throws {
         guard timeAdjustmentSaveMode == .all,
               (timeOffset != nil || timezoneOverride != nil) else {
             return

--- a/Sources/PhotoKitGeotagger/PHAssetGeotaggingItem.swift
+++ b/Sources/PhotoKitGeotagger/PHAssetGeotaggingItem.swift
@@ -42,7 +42,7 @@ public final class PHAssetGeotaggingItem: @unchecked Sendable, GeotaggingItemPro
     
     // MARK: - GeotaggingItemProtocol
     
-    public func skip(with error: Error) throws {
+    public func skip(with error: Error) async throws {
         guard timeAdjustmentSaveMode == .all,
               self.timeOffset != nil,
               let adjustedDate = self.date else {
@@ -53,9 +53,7 @@ public final class PHAssetGeotaggingItem: @unchecked Sendable, GeotaggingItemPro
             throw PHAssetGeotaggingError.batchProcessorNotAvailable
         }
         
-        Task {
-            try await batchProcessor.recordTimeAdjustment(asset: self.asset, adjustedDate: adjustedDate)
-        }
+        try await batchProcessor.recordTimeAdjustment(asset: self.asset, adjustedDate: adjustedDate)
     }
     
     public func apply(_ geotag: Geotag) async throws {

--- a/Tests/GeotaggerTests/Mocks/MockGeotaggingItem.swift
+++ b/Tests/GeotaggerTests/Mocks/MockGeotaggingItem.swift
@@ -35,7 +35,7 @@ final class MockGeotaggingItem: GeotaggingItemProtocol, @unchecked Sendable {
         }
     }
     
-    func skip(with error: Error) throws {
+    func skip(with error: Error) async throws {
         lock.withLock {
             _skipError = error
         }


### PR DESCRIPTION
## Summary
- Implements timeOffset and timeAdjustmentSaveMode properties in PHAssetGeotaggingItem to match the functionality available in ImageIOGeotaggingItem
- Allows users to adjust photo timestamps for accurate geotag matching when using PhotoKit
- Updates PHAssetGeotagBatchProcessor to handle time-only adjustments

## Changes
1. **PHAssetGeotaggingItem Updates:**
   - Added `timeOffset: TimeInterval?` property
   - Added `timeAdjustmentSaveMode: TimeAdjustmentSaveMode` property
   - Modified `date` computed property to apply timeOffset
   - Implemented `skip()` method to handle time adjustments based on save mode
   - Updated `apply()` to pass adjusted date when appropriate

2. **PHAssetGeotagBatchProcessor Updates:**
   - Added support for optional `adjustedDate` parameter in `recordGeotag`
   - New `recordTimeAdjustment` method for time-only updates
   - Updated batch processing to handle both geotag and creationDate changes

## Important Notes
- Unlike ImageIOGeotaggingItem, timezoneOverride is not included as PhotoKit cannot persist timezone metadata
- Time adjustments are persisted by updating the PHAsset's creationDate property
- The implementation respects TimeAdjustmentSaveMode settings (.all, .tagged, .none)

## Test Plan
- [ ] Build succeeds without warnings
- [ ] Time offset correctly adjusts dates for geotag matching
- [ ] TimeAdjustmentSaveMode.all saves time adjustments for all items
- [ ] TimeAdjustmentSaveMode.tagged saves time adjustments only for geotagged items
- [ ] TimeAdjustmentSaveMode.none doesn't save any time adjustments

🤖 Generated with [Claude Code](https://claude.ai/code)