### PR TITLE
Add iOS/iPadOS support to library products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Geotagger",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v13),
+        .iOS(.v15)
     ],
     products: [
         .executable(
@@ -20,7 +21,7 @@ let package = Package(
         .library(
             name: "PhotoKitGeotagger",
             targets: ["PhotoKitGeotagger"]
-        ),
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/vincentneo/CoreGPX", .upToNextMinor(from: "0.9.0")),
@@ -54,6 +55,6 @@ let package = Package(
                 "Geotagger",
                 "CLI"
             ]
-        ),
+        )
     ]
 )


### PR DESCRIPTION
## Summary
- Added iOS 15+ platform support to Package.swift
- Enabled iOS/iPadOS builds for Geotagger and PhotoKitGeotagger library targets
- No code changes required - all APIs used are cross-platform

## Test plan
- [ ] Build the package for iOS target
- [ ] Verify Geotagger library compiles for iOS
- [ ] Verify PhotoKitGeotagger library compiles for iOS
- [ ] CLI target remains macOS-only as expected

🤖 Generated with [Claude Code](https://claude.ai/code)