### PR TITLE
Update iOS deployment target to iOS 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Geotagger",
     platforms: [
         .macOS(.v13),
-        .iOS(.v15)
+        .iOS(.v16)
     ],
     products: [
         .executable(


### PR DESCRIPTION
## Summary
- Updated iOS deployment target from iOS 15 to iOS 16
- This aligns with macOS 13 deployment target (both released in 2022)

## Test plan
- [ ] Verify package builds for iOS 16+
- [ ] Confirm no API compatibility issues

🤖 Generated with [Claude Code](https://claude.ai/code)