### PR TITLE
Fix photo metadata serialization and PhotoKit altitude handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,8 @@ let package = Package(
             name: "GeotaggerTests",
             dependencies: [
                 "Geotagger",
-                "CLI"
+                "CLI",
+                "PhotoKitGeotagger"
             ]
         )
     ]

--- a/Sources/Geotagger/ImageIO/Geotag+GPSDictionary.swift
+++ b/Sources/Geotagger/ImageIO/Geotag+GPSDictionary.swift
@@ -41,6 +41,10 @@ extension Geotag {
         guard let value = (gpsDictionary[kCGImagePropertyGPSLatitude] as? NSNumber)?.doubleValue else {
             return nil
         }
+        if let reference = gpsDictionary[kCGImagePropertyGPSLatitudeRef] as? String,
+           reference.lowercased() == "s" {
+            return .degrees(value * (-1))
+        }
         return .degrees(value)
     }
 

--- a/Sources/Geotagger/ImageIO/ImageIOWriter.swift
+++ b/Sources/Geotagger/ImageIO/ImageIOWriter.swift
@@ -49,6 +49,7 @@ public struct ImageIOWriter: ImageIOWriterProtocol {
             for (key, value) in geotag.asGPSDictionary {
                 CGImageMetadataSetValueMatchingImageProperty(mutableMetadata, kCGImagePropertyGPSDictionary, key, value as CFTypeRef)
             }
+            self.synchronizeXMPGPSMetadata(for: geotag, in: mutableMetadata)
         }
 
         // Apply timezone to EXIF metadata - priority: timezoneOverride > originalTimezone
@@ -118,6 +119,31 @@ extension ImageIOWriterProtocol {
 
 // MARK: - Private Methods
 extension ImageIOWriter {
+    private func synchronizeXMPGPSMetadata(for geotag: Geotag, in metadata: CGMutableImageMetadata) {
+        let latitude = geotag.location.latitude.degrees
+        let longitude = geotag.location.longitude.degrees
+
+        // ImageIO also emits XMP-exif GPS tags. For southern latitudes it serializes
+        // the coordinate string with an "N" suffix, which conflicts with the ref tag
+        // and confuses downstream apps. Overwrite the XMP GPS fields explicitly.
+        CGImageMetadataSetValueWithPath(metadata, nil, "exif:GPSLatitude" as CFString, self.xmpGPSCoordinateString(for: latitude, positiveDirection: "N", negativeDirection: "S") as CFTypeRef)
+        CGImageMetadataSetValueWithPath(metadata, nil, "exif:GPSLatitudeRef" as CFString, (latitude < 0 ? "S" : "N") as CFTypeRef)
+        CGImageMetadataSetValueWithPath(metadata, nil, "exif:GPSLongitude" as CFString, self.xmpGPSCoordinateString(for: longitude, positiveDirection: "E", negativeDirection: "W") as CFTypeRef)
+        CGImageMetadataSetValueWithPath(metadata, nil, "exif:GPSLongitudeRef" as CFString, (longitude < 0 ? "W" : "E") as CFTypeRef)
+    }
+
+    private func xmpGPSCoordinateString(for value: Double, positiveDirection: String, negativeDirection: String) -> String {
+        let absoluteValue = abs(value)
+        let degrees = Int(absoluteValue.rounded(.down))
+        let minutes = (absoluteValue - Double(degrees)) * 60
+        let direction = value < 0 ? negativeDirection : positiveDirection
+        return String(format: "%d,%.7f%@",
+                      locale: Locale(identifier: "en_US_POSIX"),
+                      degrees,
+                      minutes,
+                      direction)
+    }
+
     private func isValidTimezoneOffset(_ timezone: String) -> Bool {
         // Valid formats: "+05:00", "-08:00", "Z"
         if timezone == "Z" {

--- a/Sources/PhotoKitGeotagger/PHAssetGeoAnchorsLoader.swift
+++ b/Sources/PhotoKitGeotagger/PHAssetGeoAnchorsLoader.swift
@@ -9,6 +9,25 @@ import Foundation
 import Photos
 import Geotagger
 
+enum PHAssetLocationMapper {
+    static func geotaggerLocation(from location: CLLocation) -> Location {
+        let coordinate = location.coordinate
+
+        return Location(
+            latitude: .degrees(coordinate.latitude),
+            longitude: .degrees(coordinate.longitude),
+            altitude: self.altitude(from: location)
+        )
+    }
+
+    static func altitude(from location: CLLocation) -> Altitude? {
+        guard location.verticalAccuracy >= 0 else {
+            return nil
+        }
+        return Altitude(value: location.altitude, reference: 0)
+    }
+}
+
 public class PHAssetGeoAnchorsLoader: GeoAnchorsLoaderProtocol {
     // MARK: - Private properties
 
@@ -29,18 +48,9 @@ public class PHAssetGeoAnchorsLoader: GeoAnchorsLoaderProtocol {
                 return nil
             }
 
-            let coordinate = location.coordinate
-            let altitude = location.altitude != 0 ? Altitude(value: location.altitude, reference: 0) : nil
-
-            let geoLocation = Location(
-                latitude: CircularCoordinate.degrees(coordinate.latitude),
-                longitude: CircularCoordinate.degrees(coordinate.longitude),
-                altitude: altitude
-            )
-
             return GeoAnchor(
                 date: creationDate,
-                location: geoLocation
+                location: PHAssetLocationMapper.geotaggerLocation(from: location)
             )
         }
     }

--- a/Sources/PhotoKitGeotagger/PHAssetGeotagBatchProcessor.swift
+++ b/Sources/PhotoKitGeotagger/PHAssetGeotagBatchProcessor.swift
@@ -9,6 +9,27 @@ import Foundation
 import Photos
 import Geotagger
 
+enum PHAssetLocationBuilder {
+    private static let validHorizontalAccuracy = 1.0
+    private static let validVerticalAccuracy = 1.0
+
+    static func phAssetLocation(from geotag: Geotag, timestamp: Date) -> CLLocation {
+        let altitude = geotag.location.altitude?.value ?? 0
+        let verticalAccuracy = geotag.location.altitude == nil ? -1.0 : Self.validVerticalAccuracy
+
+        return CLLocation(
+            coordinate: CLLocationCoordinate2D(
+                latitude: geotag.location.latitude.degrees,
+                longitude: geotag.location.longitude.degrees
+            ),
+            altitude: altitude,
+            horizontalAccuracy: Self.validHorizontalAccuracy,
+            verticalAccuracy: verticalAccuracy,
+            timestamp: timestamp
+        )
+    }
+}
+
 public struct PHAssetGeotagResult {
     public let asset: PHAsset
     public let result: Result<Geotag, Error>
@@ -112,14 +133,8 @@ public actor PHAssetGeotagBatchProcessor {
 
                     // Apply geotag if provided
                     if let geotag = request.geotag {
-                        changeRequest.location = CLLocation(
-                            coordinate: CLLocationCoordinate2D(
-                                latitude: geotag.location.latitude.degrees,
-                                longitude: geotag.location.longitude.degrees
-                            ),
-                            altitude: geotag.location.altitude?.value ?? 0,
-                            horizontalAccuracy: kCLLocationAccuracyBest,
-                            verticalAccuracy: kCLLocationAccuracyBest,
+                        changeRequest.location = PHAssetLocationBuilder.phAssetLocation(
+                            from: geotag,
                             timestamp: request.adjustedDate ?? request.asset.creationDate ?? Date()
                         )
                     }

--- a/Tests/GeotaggerTests/ImageIOGPSMetadataTests.swift
+++ b/Tests/GeotaggerTests/ImageIOGPSMetadataTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+@testable import Geotagger
+
+final class ImageIOGPSMetadataTests: XCTestCase {
+
+    func testGeotagReaderAppliesSouthernLatitudeReference() throws {
+        let geotag = try XCTUnwrap(Geotag(gpsDictionary: [
+            kCGImagePropertyGPSLatitude: 33.713525,
+            kCGImagePropertyGPSLatitudeRef: "S",
+            kCGImagePropertyGPSLongitude: 151.175808,
+            kCGImagePropertyGPSLongitudeRef: "E"
+        ]))
+
+        XCTAssertEqual(geotag.location.latitude.degrees, -33.713525, accuracy: 0.000001)
+        XCTAssertEqual(geotag.location.longitude.degrees, 151.175808, accuracy: 0.000001)
+    }
+
+    func testGeotagReaderAppliesWesternLongitudeReference() throws {
+        let geotag = try XCTUnwrap(Geotag(gpsDictionary: [
+            kCGImagePropertyGPSLatitude: 37.7749,
+            kCGImagePropertyGPSLatitudeRef: "N",
+            kCGImagePropertyGPSLongitude: 122.4194,
+            kCGImagePropertyGPSLongitudeRef: "W"
+        ]))
+
+        XCTAssertEqual(geotag.location.latitude.degrees, 37.7749, accuracy: 0.000001)
+        XCTAssertEqual(geotag.location.longitude.degrees, -122.4194, accuracy: 0.000001)
+    }
+
+    func testImageIOWriterKeepsSouthernLatitudeConsistentAcrossEXIFAndXMP() throws {
+        let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let sourceURL = directoryURL.appendingPathComponent("source.jpg")
+        let destinationURL = directoryURL.appendingPathComponent("tagged.jpg")
+        try self.createTestJPEG(at: sourceURL)
+
+        let writer = ImageIOWriter()
+        let geotag = Geotag(
+            location: Location(
+                latitude: .degrees(-33.713525),
+                longitude: .degrees(151.175808),
+                altitude: Altitude(value: 189, reference: 0)
+            )
+        )
+
+        try writer.write(
+            geotag: geotag,
+            timezoneOverride: nil,
+            originalTimezone: nil,
+            adjustedDate: nil,
+            toPhotoAt: sourceURL,
+            saveNewVersionAt: destinationURL
+        )
+
+        let reader = ImageIOReader()
+        let savedGeotag = try XCTUnwrap(reader.readGeotagFromPhoto(at: destinationURL))
+        XCTAssertEqual(savedGeotag.location.latitude.degrees, -33.713525, accuracy: 0.0001)
+        XCTAssertEqual(savedGeotag.location.longitude.degrees, 151.175808, accuracy: 0.0001)
+
+        guard let imageSource = CGImageSourceCreateWithURL(destinationURL as CFURL, nil),
+              let metadata = CGImageSourceCopyMetadataAtIndex(imageSource, 0, nil) else {
+            XCTFail("Expected metadata in written image")
+            return
+        }
+
+        let xmpLatitude = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLatitude" as CFString) as String?
+        let xmpLatitudeRef = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLatitudeRef" as CFString) as String?
+        let xmpLongitudeRef = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLongitudeRef" as CFString) as String?
+
+        XCTAssertEqual(xmpLatitudeRef, "S")
+        XCTAssertEqual(xmpLongitudeRef, "E")
+        XCTAssertEqual(xmpLatitude?.last, "S")
+    }
+
+    func testImageIOWriterKeepsWesternLongitudeConsistentAcrossEXIFAndXMP() throws {
+        let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let sourceURL = directoryURL.appendingPathComponent("source.jpg")
+        let destinationURL = directoryURL.appendingPathComponent("tagged.jpg")
+        try self.createTestJPEG(at: sourceURL)
+
+        let writer = ImageIOWriter()
+        let geotag = Geotag(
+            location: Location(
+                latitude: .degrees(37.7749),
+                longitude: .degrees(-122.4194),
+                altitude: nil
+            )
+        )
+
+        try writer.write(
+            geotag: geotag,
+            timezoneOverride: nil,
+            originalTimezone: nil,
+            adjustedDate: nil,
+            toPhotoAt: sourceURL,
+            saveNewVersionAt: destinationURL
+        )
+
+        let reader = ImageIOReader()
+        let savedGeotag = try XCTUnwrap(reader.readGeotagFromPhoto(at: destinationURL))
+        XCTAssertEqual(savedGeotag.location.latitude.degrees, 37.7749, accuracy: 0.0001)
+        XCTAssertEqual(savedGeotag.location.longitude.degrees, -122.4194, accuracy: 0.0001)
+
+        guard let imageSource = CGImageSourceCreateWithURL(destinationURL as CFURL, nil),
+              let metadata = CGImageSourceCopyMetadataAtIndex(imageSource, 0, nil) else {
+            XCTFail("Expected metadata in written image")
+            return
+        }
+
+        let xmpLongitude = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLongitude" as CFString) as String?
+        let xmpLongitudeRef = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLongitudeRef" as CFString) as String?
+        let xmpLatitudeRef = CGImageMetadataCopyStringValueWithPath(metadata, nil, "exif:GPSLatitudeRef" as CFString) as String?
+
+        XCTAssertEqual(xmpLatitudeRef, "N")
+        XCTAssertEqual(xmpLongitudeRef, "W")
+        XCTAssertEqual(xmpLongitude?.last, "W")
+    }
+
+    private func createTestJPEG(at url: URL) throws {
+        let bytes: [UInt8] = [255, 0, 0, 255]
+        let data = Data(bytes)
+        guard let provider = CGDataProvider(data: data as CFData),
+              let image = CGImage(
+                width: 1,
+                height: 1,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent
+              ),
+              let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.jpeg.identifier as CFString, 1, nil) else {
+            throw TestError.failedToCreateImage
+        }
+
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw TestError.failedToFinalizeImage
+        }
+    }
+
+    private enum TestError: Error {
+        case failedToCreateImage
+        case failedToFinalizeImage
+    }
+}

--- a/Tests/GeotaggerTests/PhotoKitMetadataTests.swift
+++ b/Tests/GeotaggerTests/PhotoKitMetadataTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import CoreLocation
+@testable import Geotagger
+@testable import PhotoKitGeotagger
+
+final class PhotoKitMetadataTests: XCTestCase {
+
+    func testPHAssetLoaderPreservesZeroAltitudeWhenVerticalAccuracyIsValid() {
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -33.713525, longitude: 151.175808),
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        let mapped = PHAssetLocationMapper.geotaggerLocation(from: location)
+
+        XCTAssertEqual(mapped.latitude.degrees, -33.713525, accuracy: 0.000001)
+        XCTAssertEqual(mapped.longitude.degrees, 151.175808, accuracy: 0.000001)
+        XCTAssertEqual(mapped.altitude?.value ?? .nan, 0, accuracy: 0.000001)
+    }
+
+    func testPHAssetLoaderDropsAltitudeWhenVerticalAccuracyIsInvalid() {
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: -33.713525, longitude: 151.175808),
+            altitude: 123,
+            horizontalAccuracy: 5,
+            verticalAccuracy: -1,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        let mapped = PHAssetLocationMapper.geotaggerLocation(from: location)
+
+        XCTAssertNil(mapped.altitude)
+    }
+
+    func testPHAssetWriterMarksMissingAltitudeAsInvalid() {
+        let geotag = Geotag(
+            location: Location(
+                latitude: .degrees(37.7749),
+                longitude: .degrees(-122.4194),
+                altitude: nil
+            )
+        )
+
+        let location = PHAssetLocationBuilder.phAssetLocation(
+            from: geotag,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        XCTAssertEqual(location.coordinate.latitude, 37.7749, accuracy: 0.000001)
+        XCTAssertEqual(location.coordinate.longitude, -122.4194, accuracy: 0.000001)
+        XCTAssertEqual(location.altitude, 0, accuracy: 0.000001)
+        XCTAssertLessThan(location.verticalAccuracy, 0)
+    }
+
+    func testPHAssetWriterPreservesExplicitZeroAltitude() {
+        let geotag = Geotag(
+            location: Location(
+                latitude: .degrees(37.7749),
+                longitude: .degrees(-122.4194),
+                altitude: Altitude(value: 0, reference: 0)
+            )
+        )
+
+        let location = PHAssetLocationBuilder.phAssetLocation(
+            from: geotag,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        XCTAssertEqual(location.altitude, 0, accuracy: 0.000001)
+        XCTAssertGreaterThanOrEqual(location.verticalAccuracy, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- fix ImageIO GPS metadata round-tripping for southern latitudes and keep XMP GPS tags consistent with EXIF
- preserve missing-vs-zero altitude semantics in the PHAsset load/write path
- add regression tests for GPS metadata and PhotoKit metadata mapping, including western longitude coverage

## Testing
- swift test